### PR TITLE
Fixing the channel's name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Coding Rainbow Topics
+# Coding Train Topics
 
-This repo is for tracking Coding Rainbow topics.  You can [browse existing suggestions](https://github.com/CodingRainbow/Rainbow-Topics/issues) as well as [suggest topics](https://github.com/CodingRainbow/Rainbow-Topics/issues/new).  The suggestions can also just be programming questions (general or about specific code) which I'll answer in my "Q&A" series. Please be descriptive about your suggestions and include links if possible, so that others can understand your idea easily.
+This repo is for tracking Coding Train topics.  You can [browse existing suggestions](https://github.com/CodingRainbow/Rainbow-Topics/issues) as well as [suggest topics](https://github.com/CodingRainbow/Rainbow-Topics/issues/new).  The suggestions can also just be programming questions (general or about specific code) which I'll answer in my "Q&A" series. Please be descriptive about your suggestions and include links if possible, so that others can understand your idea easily.
 
 In addition, you can use the "github issue" reactions (thumbs up) to upvote suggestions.
 


### PR DESCRIPTION
Maybe someone forgot to change "The Coding Rainbow" to "The Coding Train" in the README file.